### PR TITLE
Fix keyspace infos parsing

### DIFF
--- a/exporter/info.go
+++ b/exporter/info.go
@@ -127,7 +127,7 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 }
 
 /*
-	valid example: db0:keys=1,expires=0,avg_ttl=0
+valid example: db0:keys=1,expires=0,avg_ttl=0
 */
 func parseDBKeyspaceString(inputKey string, inputVal string) (keysTotal float64, keysExpiringTotal float64, avgTTL float64, ok bool) {
 	log.Debugf("parseDBKeyspaceString inputKey: [%s] inputVal: [%s]", inputKey, inputVal)
@@ -138,7 +138,7 @@ func parseDBKeyspaceString(inputKey string, inputVal string) (keysTotal float64,
 	}
 
 	split := strings.Split(inputVal, ",")
-	if len(split) != 4 {
+	if len(split) != 3 {
 		log.Debugf("parseDBKeyspaceString strings.Split(inputVal) invalid: %#v", split)
 		return
 	}
@@ -167,8 +167,8 @@ func parseDBKeyspaceString(inputKey string, inputVal string) (keysTotal float64,
 }
 
 /*
-	slave0:ip=10.254.11.1,port=6379,state=online,offset=1751844676,lag=0
-	slave1:ip=10.254.11.2,port=6379,state=online,offset=1751844222,lag=0
+slave0:ip=10.254.11.1,port=6379,state=online,offset=1751844676,lag=0
+slave1:ip=10.254.11.2,port=6379,state=online,offset=1751844222,lag=0
 */
 func parseConnectedSlaveString(slaveName string, keyValues string) (offset float64, ip string, port string, state string, lag float64, ok bool) {
 	ok = false


### PR DESCRIPTION
We were wondering why, after running `dbsize scan` properly, our Grafana dashboard were still showing nothing for the estimated keys.

`parseDBKeyspaceString` receives two arguments:

- `inputKey` which should be the database/namespace
- `inputVal` which should be the keyspace numbers as string

Right now, the split length condition returns nothing if there are not four elements after the split on `inputVal`. But the `inputVal` data doesn't contain the database name, it is in `inputKey`, therefore we should look for three elements, not four.

As the code says, a valid example is: 

> db0:keys=1,expires=0,avg_ttl=0

- `inputKey` is `db0`
- `inputVal` is `keys=1,expires=0,avg_ttl=0` (three elements, not four when splitted by comma)

