### PR TITLE
Improve keyspace parsing with expired keys

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -104,7 +104,6 @@ func NewKvrocksExporter(kvrocksURI string, opts Options) (*Exporter, error) {
 			"monitor_clients":   "monitor_clients",
 
 			// # Memory
-
 			"used_memory":     "memory_used_bytes",
 			"used_memory_rss": "memory_used_rss_bytes",
 			"used_memory_lua": "memory_used_lua_bytes",
@@ -186,6 +185,7 @@ func NewKvrocksExporter(kvrocksURI string, opts Options) (*Exporter, error) {
 		"db_avg_ttl_seconds":                   {txt: "Avg TTL in seconds", lbls: []string{"db"}},
 		"db_keys":                              {txt: "Total number of keys by DB", lbls: []string{"db"}},
 		"db_keys_expiring":                     {txt: "Total number of expiring keys by DB", lbls: []string{"db"}},
+		"db_keys_expired":                      {txt: "Total number of expired keys by DB", lbls: []string{"db"}},
 		"exporter_last_scrape_error":           {txt: "The last scrape error status.", lbls: []string{"err"}},
 		"instance_info":                        {txt: "Information about the kvrocks instance", lbls: []string{"role", "version", "git_sha1", "os", "tcp_port", "gcc_version", "process_id"}},
 		"last_slow_execution_duration_seconds": {txt: `The amount of time needed for last slow execution, in seconds`},

--- a/exporter/info_test.go
+++ b/exporter/info_test.go
@@ -14,10 +14,10 @@ import (
 
 func TestKeyspaceStringParser(t *testing.T) {
 	tsts := []struct {
-		db                        string
-		stats                     string
-		keysTotal, keysEx, avgTTL float64
-		ok                        bool
+		db                                     string
+		stats                                  string
+		keysTotal, keysEx, avgTTL, keysExpired float64
+		ok                                     bool
 	}{
 		{db: "xxx", stats: "", ok: false},
 		{db: "xxx", stats: "keys=1,expires=0,avg_ttl=0", ok: false},
@@ -28,20 +28,20 @@ func TestKeyspaceStringParser(t *testing.T) {
 		{db: "db3", stats: "keys=abcde,expires=0", ok: false},
 		{db: "db3", stats: "keys=213,expires=xxx", ok: false},
 		{db: "db3", stats: "keys=123,expires=0,avg_ttl=zzz", ok: false},
-
-		{db: "db0", stats: "keys=1,expires=0,avg_ttl=0", keysTotal: 1, keysEx: 0, avgTTL: 0, ok: true},
+		{db: "db0", stats: "keys=22113592,expires=21683101,avg_ttl=3816396,expired=340250", keysTotal: 22113592, keysEx: 21683101, avgTTL: 3816.396, keysExpired: 340250, ok: true},
+		{db: "db0", stats: "keys=1,expires=0,avg_ttl=0", keysTotal: 1, keysEx: 0, avgTTL: 0, keysExpired: 0, ok: true},
 	}
 
 	for _, tst := range tsts {
-		if kt, kx, ttl, ok := parseDBKeyspaceString(tst.db, tst.stats); true {
+		if kt, kx, ttl, kexp, ok := parseDBKeyspaceString(tst.db, tst.stats); true {
 
 			if ok != tst.ok {
 				t.Errorf("failed for: db:%s stats:%s", tst.db, tst.stats)
 				continue
 			}
 
-			if ok && (kt != tst.keysTotal || kx != tst.keysEx || ttl != tst.avgTTL) {
-				t.Errorf("values not matching, db:%s stats:%s   %f %f %f", tst.db, tst.stats, kt, kx, ttl)
+			if ok && (kt != tst.keysTotal || kx != tst.keysEx || ttl != tst.avgTTL || kexp != tst.keysExpired) {
+				t.Errorf("values not matching, db:%s stats:%s   %f %f %f", tst.db, tst.stats, kt, kx, ttl, kexp)
 			}
 		}
 	}


### PR DESCRIPTION
The keyspace parsing was not working anymore due to the "Last dbsize scan" sentence that we try to catch. It has changed in Kvrocks (new word, caps lock etc) and it wasn't catch anymore by the exporter conditions.

I also added support for the number of "expired keys". 

We can edit the Grafana dashboard [here](https://grafana.com/grafana/dashboards/15286-kvrocks/) to add the new metric `db_keys_expired`. I did it on my Grafana:

![Screenshot 2024-08-09 à 20 49 10](https://github.com/user-attachments/assets/de16780c-5b4f-4312-b6b5-3da8fd5f76d6)
