### PR TITLE
feat: add a default Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.23-alpine3.21 AS build
+
+ARG TARGETARCH
+
+RUN apk update && apk upgrade && apk add make
+
+WORKDIR /opt
+
+COPY . .
+
+RUN make build-binaries ARCH=${TARGETARCH}
+
+FROM alpine:3.21
+
+COPY --from=build /kvrocks_exporter/.build/kvrocks_exporter /kvrocks_exporter
+
+COPY ./LICENSE /
+
+EXPOSE 9121/tcp
+
+ENTRYPOINT [ "/kvrocks_exporter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ RUN make build-binaries ARCH=${TARGETARCH}
 
 FROM alpine:3.21
 
+RUN apk update && apk upgrade
+
 COPY --from=build /kvrocks_exporter/.build/kvrocks_exporter /kvrocks_exporter
 
-COPY ./LICENSE /
+COPY --from=build ./LICENSE /
 
 EXPOSE 9121/tcp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go build .
 
 FROM alpine:3.21
 
-RUN apk update && apk upgrade
+RUN apk update && apk upgrade && apk add --no-cache curl
 
 WORKDIR /opt
 
@@ -20,5 +20,7 @@ COPY --from=build /opt/kvrocks_exporter kvrocks_exporter
 COPY --from=build /opt/LICENSE .
 
 EXPOSE 9121/tcp
+
+HEALTHCHECK --interval=30s --timeout=1s --start-period=5s --retries=3 CMD curl --fail -s http://localhost:9121/health | grep 'ok' || exit 1
 
 ENTRYPOINT [ "/kvrocks_exporter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,23 @@
 FROM golang:1.23-alpine3.21 AS build
 
-ARG TARGETARCH
-
-RUN apk update && apk upgrade && apk add make
+ARG TARGETARCH=amd64
+ENV GOARCH=${TARGETARCH}
 
 WORKDIR /opt
 
 COPY . .
 
-RUN make build-binaries ARCH=${TARGETARCH}
+RUN go build . 
 
 FROM alpine:3.21
 
 RUN apk update && apk upgrade
 
-COPY --from=build /kvrocks_exporter/.build/kvrocks_exporter /kvrocks_exporter
+WORKDIR /opt
 
-COPY --from=build ./LICENSE /
+COPY --from=build /opt/kvrocks_exporter kvrocks_exporter
+
+COPY --from=build /opt/LICENSE .
 
 EXPOSE 9121/tcp
 


### PR DESCRIPTION
Add an default Dockerfile for manual build container at user machine.

Based on go1.23-alpine3.21  as builder and latest alpine3.21 for running.