### PR TITLE
ci: update base image to alpine 2.21

### DIFF
--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -25,7 +25,7 @@ kos:
       - "{{.Version}}"
       - latest
     preserve_import_paths: false
-    base_image: alpine:3.20
+    base_image: alpine:3.21
     bare: true 
     ldflags:
       - "-X main.BuildVersion={{ .Version }}"


### PR DESCRIPTION
Change default base image at goreleaser to alpine:3.21