### PR TITLE
fix: deprecated kos.repository

### DIFF
--- a/.github/goreleaser.yml
+++ b/.github/goreleaser.yml
@@ -20,7 +20,8 @@ builds:
       - amd64
       - arm64
 kos:
-  - repository: docker.io/kvrocks/kvrocks-exporter
+  - repositories: 
+      - docker.io/kvrocks/kvrocks-exporter
     tags:
       - "{{.Version}}"
       - latest


### PR DESCRIPTION
Fix warning: DEPRECATED: kos.repository should not be used anymore, check https://goreleaser.com/deprecations#kosrepository for more info