### PR TITLE
Improve comment line skip

### DIFF
--- a/exporter/info.go
+++ b/exporter/info.go
@@ -46,7 +46,6 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 		log.Debugf("info: %s", line)
 
 		if len(line) > 0 && strings.HasPrefix(line, "# ") {
-
 			skip := false
 			for _, skipPrefix := range linePrefixesToSkip {
 				if strings.HasPrefix(line, skipPrefix) {
@@ -54,7 +53,6 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 					break
 				}
 			}
-
 			if skip {
 				continue
 			}

--- a/exporter/info.go
+++ b/exporter/info.go
@@ -34,13 +34,31 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 	lines := strings.Split(info, "\n")
 	masterHost := ""
 	masterPort := ""
+
+	linePrefixesToSkip := []string{
+		"# Last DBSIZE SCAN",
+		"# Last scan db time",
+		"# WARN:",
+	}
+
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		log.Debugf("info: %s", line)
+
 		if len(line) > 0 && strings.HasPrefix(line, "# ") {
-			if strings.HasPrefix(line, "# Last DBSIZE SCAN") {
+
+			skip := false
+			for _, skipPrefix := range linePrefixesToSkip {
+				if strings.HasPrefix(line, skipPrefix) {
+					skip = true
+					break
+				}
+			}
+
+			if skip {
 				continue
 			}
+
 			fieldClass = line[2:]
 			log.Debugf("set fieldClass: %s", fieldClass)
 			continue


### PR DESCRIPTION
Closes https://github.com/RocksLabs/kvrocks_exporter/issues/56.

In Local testing with kvrocks 2.7, before this change:

<img width="337" alt="before" src="https://github.com/user-attachments/assets/c36be631-77ad-4020-8c3a-488db438ec1f" />

After add skip for legacy comment:

<img width="350" alt="after" src="https://github.com/user-attachments/assets/8afa3552-66af-470b-aa3d-27ca534dc850" />

It seems work well with old version now.