### PR TITLE
Fix CommandStats parsing

### DIFF
--- a/exporter/info.go
+++ b/exporter/info.go
@@ -90,7 +90,7 @@ func (e *Exporter) extractInfoMetrics(ch chan<- prometheus.Metric, info string, 
 		case "Server":
 			e.handleMetricsServer(ch, fieldKey, fieldValue)
 
-		case "Commandstats":
+		case "Commandstats", "CommandStats":
 			e.handleMetricsCommandStats(ch, fieldKey, fieldValue)
 			continue
 


### PR DESCRIPTION
It looks like the recent [change](https://github.com/apache/kvrocks/pull/2778) in kvrocks, changed the INFO section header 
From:
```
# Commandstats
cmdstat_client:calls=59,usec=124,usec_per_call=2
cmdstat_command:calls=2,usec=851,usec_per_call=425
cmdstat_config:calls=59,usec=5398,usec_per_call=91
```

To:
```
# CommandStats
cmdstat_client:calls=13,usec=21,usec_per_call=1.6153846153846154
cmdstat_command:calls=1,usec=442,usec_per_call=442
```

This broke the cmd parsing.
This PR add supports for `Commandstats` and `CommandStats`